### PR TITLE
Fixed case in multitrack when new-end is infinite

### DIFF
--- a/video/private/video.rkt
+++ b/video/private/video.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 #|
-   Copyright 2016-2017 Leif Andersen
+   Copyright 2016-2017 Leif Andersen, Benjamin Chung
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -664,8 +664,9 @@
       (define new-end (get-property node "end" +inf.0))
       (values (dict-set raw-nodes t (cons node index))
               (min start (get-property node "start" 0))
-              (unless (= new-end +inf.0)
-                (max end new-end)))))
+              (if (= new-end +inf.0)
+                  end
+                  (max end new-end)))))
   ;; Convert all clips to a compatible length
   (define nodes
     (hash-copy


### PR DESCRIPTION
Multitrack was previously computing the end of videos incorrectly, causing the trivial case (where the end of a video to composite was infinite, therefore the length of the combined video should not change) to cause a crash, due to the unless function returning void when the given condition is satisfied.

This change replaces the unless condition in multitrack with an if statement, correctly leaving the length unchanged when a clip of arbitrary length is composited with a track of a known length.